### PR TITLE
Add in GPIO, UART, I2C, and SPI DTS definitions for Tachyon

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -15,13 +15,11 @@
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 #include <dt-bindings/regulator/qcom,rpmh-regulator.h>
-#include <dt-bindings/iio/qcom,spmi-adc7-pmr735a.h>
 #include "sc7280.dtsi"
 #include "pm7250b.dtsi"
 #include "pm7325.dtsi"
 #include "pm8350c.dtsi"
 #include "pmk8350.dtsi"
-#include "pmr735a.dtsi"
 
 /delete-node/ &rmtfs_mem;
 
@@ -32,6 +30,8 @@
 	aliases {
 		serial0 = &uart5;
 		serial1 = &uart7;
+		serial2 = &uart8;
+		serial3 = &uart12;
 	};
 
 	chosen {
@@ -197,7 +197,7 @@
 					reg = <2>;
 
 					pmic_glink_sbu: endpoint {
-						remote-endpoint = <&fsa4480_sbu_mux>;
+						// remote-endpoint = <&fsa4480_sbu_mux>;
 					};
 				};
 			};
@@ -534,35 +534,6 @@
 			regulator-max-microvolt = <3960000>;
 		};
 	};
-	regulators-2 {
-		compatible = "qcom,pmr735a-rpmh-regulators";
-		qcom,pmic-id = "e";
-
-		vreg_l2e_1p2: ldo2 {
-			regulator-min-microvolt = <1200000>;
-			regulator-max-microvolt = <1200000>;
-		};
-
-		vreg_l3e_0p9: ldo3 {
-			regulator-min-microvolt = <912000>;
-			regulator-max-microvolt = <1020000>;
-		};
-
-		vreg_l4e_1p7: ldo4 {
-			regulator-min-microvolt = <1776000>;
-			regulator-max-microvolt = <1890000>;
-		};
-
-		vreg_l5e_0p8: ldo5 {
-			regulator-min-microvolt = <800000>;
-			regulator-max-microvolt = <800000>;
-		};
-
-		vreg_l6e_0p8: ldo6 {
-			regulator-min-microvolt = <480000>;
-			regulator-max-microvolt = <904000>;
-		};
-	};
 };
 
 &gcc {
@@ -573,36 +544,6 @@
 			<GCC_MSS_Q6_MEMNOC_AXI_CLK>, <GCC_MSS_Q6SS_BOOT_CLK_SRC>,
 			<GCC_SEC_CTRL_CLK_SRC>, <GCC_WPSS_AHB_CLK>,
 			<GCC_WPSS_AHB_BDG_MST_CLK>, <GCC_WPSS_RSCP_CLK>;
-};
-
-&i2c1 {
-	qcom,load-firmware;
-	qcom,xfer-mode = <1>;
-	clock-frequency = <100000>;
-	status = "okay";
-
-	typec-mux@42 {
-		compatible = "fcs,fsa4480";
-		reg = <0x42>;
-		interrupts-extended = <&tlmm 2 IRQ_TYPE_LEVEL_LOW>;
-		vcc-supply = <&vreg_bob_3p296>;
-		mode-switch;
-		orientation-switch;
-		svid = /bits/ 16 <0xff01>;
-
-		ports {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			port@0 {
-				reg = <0>;
-
-				fsa4480_sbu_mux: endpoint {
-					remote-endpoint = <&pmic_glink_sbu>;
-				};
-			};
-		};
-	};
 };
 
 &ipa {
@@ -787,14 +728,19 @@
 };
 
 &tlmm {
-	bt_en_state: bt-en-state {
+	pinctrl-names = "default";
+	pinctrl-0 = <&header_40pin_gpio_default>, <&peri_5v_en_default>,
+       <&dsi_csi_sw_en_default>, <&dsi_csi_sw_sel_default>, <&syscon_rgb_reserved_default>,
+	   <&syscon_bls_invoke_ctrl_default>, <&syscon_reset_ctrl_default>, <&level_shifter_en_default>;
+
+	bt_en_state_default: bt-en-default-state {
 		pins = "gpio85";
 		function = "gpio";
 		output-low;
 		bias-disable;
 	};
 
-	sw_ctrl_default: sw-ctrl-default-state {
+	bt_sw_ctrl_default: bt-sw-ctrl-default-state {
 		pins = "gpio86";
 		function = "gpio";
 		bias-pull-down;
@@ -813,6 +759,15 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	header_40pin_gpio_default: header-40pin-gpio-state {
+		pins = "gpio6", "gpio18", "gpio19", "gpio24",
+		       "gpio44", "gpio61", "gpio158", "gpio165", "gpio166";
+		function = "gpio";
+		drive-strength = <6>;
+		bias-disable;
+		input-enable;
 	};
 
 	pcie1_pwr_en: pcie1-power-default-state {
@@ -852,7 +807,6 @@
 		bias-pull-up;
 	};
 
-	//
 	qup_uart7_sleep_cts: qup-uart7-sleep-cts-state {
 		pins = "gpio28";
 		function = "gpio";
@@ -914,6 +868,71 @@
 			};
 		};
 	};
+
+	peri_5v_en_default: peri-5v-en-state {
+		pins = "gpio13";
+		function = "gpio";
+		drive-strength = <2>;
+		output-high;
+		bias-disable;
+	};
+
+	dsi_csi_sw_en_default: dsi-csi-sw-en-state {
+		pins = "gpio15";
+		function = "gpio";
+		drive-strength = <2>;
+		output-low;
+		bias-disable;
+	};
+
+	dsi_csi_sw_sel_default: dsi-csi-sw-sel-state {
+		pins = "gpio68";
+		function = "gpio";
+		drive-strength = <2>;
+		output-low;
+		bias-disable;
+	};
+
+	syscon_rgb_reserved_default: syscon-rgb-reserved-state {
+		pins = "gpio20", "gpio21", "gpio77";
+		function = "gpio";
+		drive-strength = <2>;
+		input-enable;
+		bias-disable;
+	};
+
+	syscon_reset_ctrl_default: syscon-reset-ctrl-state {
+		pins = "gpio46";
+		function = "gpio";
+		drive-strength = <2>;
+		output-low;
+		bias-disable;
+	};
+
+	syscon_bls_invoke_ctrl_default: syscon-bls-invoke-ctrl-state {
+		pins = "gpio63";
+		function = "gpio";
+		drive-strength = <2>;
+		output-low;
+		bias-disable;
+	};
+
+	level_shifter_en_default: level-shifter-en-state {
+		pins = "gpio7";
+		function = "gpio";
+		drive-strength = <16>;
+		output-high;
+		bias-disable;
+	};
+
+	/* SPI14 CS1 on GPIO62 as GPIO-controlled CS */
+	spi14_cs1_gpio_default: spi14-cs1-gpio-state {
+		pins = "gpio62";
+		function = "gpio";
+		drive-strength = <2>;
+		output-high;
+		bias-disable;
+	};
 };
 
 // These are required for UFS to work
@@ -963,127 +982,6 @@
 &qup_uart5_tx {
 	drive-strength = <2>;
 	bias-disable;
-};
-
-// PCIE0 for WiFi and BT (no longer required with latest sc7280.dtsi)
-&soc {
-	// pcie0: pcie@1c00000 {
-	// 	compatible = "qcom,pcie-sc7280";
-	// 	reg = <0 0x01c00000 0 0x3000>,
-	// 			<0 0x60000000 0 0xf1d>,
-	// 			<0 0x60000f20 0 0xa8>,
-	// 			<0 0x60001000 0 0x1000>,
-	// 			<0 0x60100000 0 0x100000>;
-
-	// 	reg-names = "parf", "dbi", "elbi", "atu", "config";
-	// 	device_type = "pci";
-	// 	linux,pci-domain = <0>;
-	// 	bus-range = <0x00 0xff>;
-	// 	num-lanes = <1>; // ?
-
-	// 	#address-cells = <3>;
-	// 	#size-cells = <2>;
-
-	// 	ranges = <0x01000000 0x0 0x00000000 0x0 0x60200000 0x0 0x100000>,
-	// 			<0x02000000 0x0 0x60300000 0x0 0x60300000 0x0 0x3d00000>;
-
-	// 	//interrupts = <GIC_SPI 140 IRQ_TYPE_LEVEL_HIGH>; ?
-	// 	interrupts = <GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>;
-	// 	interrupt-names = "msi";
-	// 	#interrupt-cells = <1>;
-	// 	interrupt-map-mask = <0 0 0 0x7>;
-	// 	interrupt-map = <0 0 0 1 &intc 0 149 IRQ_TYPE_LEVEL_HIGH>, /* int_a */
-	// 			<0 0 0 2 &intc 0 150 IRQ_TYPE_LEVEL_HIGH>, /* int_b */
-	// 			<0 0 0 3 &intc 0 151 IRQ_TYPE_LEVEL_HIGH>, /* int_c */
-	// 			<0 0 0 4 &intc 0 152 IRQ_TYPE_LEVEL_HIGH>; /* int_d */
-	// 	clocks = <&gcc GCC_PCIE_0_PIPE_CLK>,
-	// 			<&gcc GCC_PCIE_0_PIPE_CLK_SRC>,
-	// 			<&pcie0_phy>,
-	// 			<&rpmhcc RPMH_CXO_CLK>,
-	// 			<&gcc GCC_PCIE_0_AUX_CLK>,
-	// 			<&gcc GCC_PCIE_0_CFG_AHB_CLK>,
-	// 			<&gcc GCC_PCIE_0_MSTR_AXI_CLK>,
-	// 			<&gcc GCC_PCIE_0_SLV_AXI_CLK>,
-	// 			<&gcc GCC_PCIE_0_SLV_Q2A_AXI_CLK>,
-	// 			<&gcc GCC_AGGRE_NOC_PCIE_TBU_CLK>,
-	// 			<&gcc GCC_DDRSS_PCIE_SF_CLK>,
-	// 			<&gcc GCC_AGGRE_NOC_PCIE_CENTER_SF_AXI_CLK>,
-	// 			<&gcc GCC_AGGRE_NOC_PCIE_0_AXI_CLK>,
-	// 			<&gcc GCC_AGGRE_NOC_PCIE_1_AXI_CLK>;
-
-	// 	clock-names = "pipe",
-	// 				"pipe_mux",
-	// 				"phy_pipe",
-	// 				"ref",
-	// 				"aux",
-	// 				"cfg",
-	// 				"bus_master",
-	// 				"bus_slave",
-	// 				"slave_q2a",
-	// 				"tbu",
-	// 				"ddrss_sf_tbu",
-	// 				"aggre_sf_axi",
-	// 				"aggre0",
-	// 				"aggre1";
-
-	// 	// assigned-clocks = <&gcc GCC_PCIE_0_AUX_CLK>;
-	// 	// assigned-clock-rates = <19200000>;
-
-	// 	resets = <&gcc GCC_PCIE_0_BCR>;
-	// 	reset-names = "pci";
-
-	// 	power-domains = <&gcc GCC_PCIE_0_GDSC>;
-
-	// 	phys = <&pcie0_phy>;
-	// 	phy-names = "pciephy";
-
-	// 	pinctrl-names = "default";
-	// 	pinctrl-0 = <&pcie0_clkreq_n>;
-
-	// 	dma-coherent;
-
-	// 	iommu-map = <0x0 &apps_smmu 0x1c00 0x1>,
-	// 			<0x100 &apps_smmu 0x1c01 0x1>;
-
-	// 	status = "okay";
-
-	// 	pcieport0: pcie@0 {
-	// 		device_type = "pci";
-	// 		reg = <0x0 0x0 0x0 0x0 0x0>;
-	// 		#address-cells = <3>;
-	// 		#size-cells = <2>;
-	// 		ranges;
-	// 		bus-range = <0x01 0xff>;
-	// 	};
-	// };
-
-	// pcie0_phy: phy@1c06000 {
-	// 	compatible = "qcom,sm8250-qmp-gen3x1-pcie-phy";
-	// 	reg = <0 0x01c06000 0 0x1000>;
-	// 	clocks = <&gcc GCC_PCIE_0_AUX_CLK>,
-	// 			<&gcc GCC_PCIE_0_CFG_AHB_CLK>,
-	// 			<&gcc GCC_PCIE_CLKREF_EN>,
-	// 			<&gcc GCC_PCIE0_PHY_RCHNG_CLK>,
-	// 			<&gcc GCC_PCIE_0_PIPE_CLK>;
-	// 	clock-names = "aux",
-	// 				"cfg_ahb",
-	// 				"ref",
-	// 				"refgen",
-	// 				"pipe";
-
-	// 	clock-output-names = "pcie_0_pipe_clk";
-	// 	#clock-cells = <0>;
-
-	// 	#phy-cells = <0>;
-
-	// 	resets = <&gcc GCC_PCIE_0_PHY_BCR>;
-	// 	reset-names = "phy";
-
-	// 	assigned-clocks = <&gcc GCC_PCIE0_PHY_RCHNG_CLK>;
-	// 	assigned-clock-rates = <100000000>;
-
-	// 	status = "okay";
-	// };
 };
 
 &pcie0 {
@@ -1146,7 +1044,7 @@
 		compatible = "qcom,wcn6855-bt";
 
 		pinctrl-names = "default";
-		pinctrl-0 = <&bt_en_state>, <&sw_ctrl_default>;
+		pinctrl-0 = <&bt_en_state_default>, <&bt_sw_ctrl_default>;
 		enable-gpios = <&tlmm 85 GPIO_ACTIVE_HIGH>; /* BT_EN */
 		swctrl-gpios = <&tlmm 86 GPIO_ACTIVE_HIGH>;
 
@@ -1365,4 +1263,55 @@
 &gpu_zap_shader {
 	firmware-name = "tachyon/a660_zap.mbn";
 	status = "okay";
+};
+
+// ES8388 audio codec
+&i2c0 {
+    status = "okay";
+    clock-frequency = <400000>;
+    qcom,load-firmware;
+};
+
+// 40Pin Header, Pin3/5
+&i2c2 {
+    status = "okay";
+    clock-frequency = <400000>;
+    qcom,load-firmware;
+};
+
+// 40Pin Header, Pin8/10/11/36
+&uart8 {
+	status = "okay";
+    qcom,load-firmware;
+};
+
+// 40Pin Header, Pin27/28
+&i2c9 {
+    status = "okay";
+    clock-frequency = <400000>;
+    qcom,load-firmware;
+};
+
+// QWIIC I2C
+&i2c10 {
+    status = "okay";
+    clock-frequency = <400000>;
+    qcom,load-firmware;
+};
+
+// Main UART via Syscon: TX/RX only
+&uart12 {
+	status = "okay";
+    qcom,load-firmware;
+	pinctrl-names = "default";
+	pinctrl-0 = <&qup_uart12_tx>, <&qup_uart12_rx>;
+};
+
+// 40Pin Header, Pin19/21/23/24/26
+&spi14 {
+	status = "okay";
+	qcom,load-firmware;
+	pinctrl-names = "default";
+	pinctrl-0 = <&qup_spi14_data_clk>, <&qup_spi14_cs>, <&spi14_cs1_gpio_default>;
+	cs-gpios = <0>, <&tlmm 62 GPIO_ACTIVE_LOW>;
 };


### PR DESCRIPTION
This PR updates the device tree for Tachyon platform:
1. Add DTS definitions for peripherals used by Tachyon, including GPIO, I2C, UART, and SPI
1. Remove unused devices pmr735a and fsa4480

[SC135806](https://app.shortcut.com/particle/story/135806/24-04-add-correct-gpio-spi-i2c-uart-peripheral-definitions-to-the-device-tree)

NOTE: `devcfg.mbn` needs to be updated to enable SPI FIFO.
[devcfg.mbn.zip](https://github.com/user-attachments/files/23124607/devcfg.mbn.zip)


