### PR TITLE
Add in docker.sh build file

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve absolute path of current working directory
+PROJECT_DIR="$(pwd)"
+TMP_DIR="${PROJECT_DIR}/.tmp"
+
+# Ensure .tmp exists
+mkdir -p "${TMP_DIR}"
+
+docker run --rm -it --privileged \
+  -v "${PROJECT_DIR}:/project" \
+  -v "${TMP_DIR}:/tmp/work" \
+  -v /dev:/dev \
+  -w /project \
+  tachyon-system-image-builder:1.3 \
+  bash


### PR DESCRIPTION
Add script to invoke the `tachyon-system-image-builder:1.3` image built when comping the tachyon-composer docker image. This provides a docker image that can compile uboot