### PR TITLE
Add generic SPI devices, fix led name, enable DSI/CSI i2c bus

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -63,6 +63,7 @@
 		compatible = "gpio-leds";
 
 		activity_led: activity_led {
+			label = "activity_led";
 			function = LED_FUNCTION_ACTIVITY;
 			linux,default-trigger = "activity";
 			gpios = <&tlmm 14 GPIO_ACTIVE_HIGH>;
@@ -1316,6 +1317,13 @@
     qcom,load-firmware;
 };
 
+// CSI/DSI I2C Bus for touch controller
+&i2c13 {
+    status = "okay";
+    clock-frequency = <400000>;
+    qcom,load-firmware;
+};
+
 // Main UART via Syscon: TX/RX only
 &uart12 {
 	status = "okay";
@@ -1331,4 +1339,15 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&qup_spi14_data_clk>, <&qup_spi14_cs>, <&spi14_cs1_gpio_default>;
 	cs-gpios = <0>, <&tlmm 62 GPIO_ACTIVE_LOW>;
+
+	spidev@0{
+		compatible = "dhcom-board";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+	};
+	spidev@1{
+		compatible = "dhcom-board";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+	};
 };


### PR DESCRIPTION
- Add generic SPI devices for user to interface with. `dhcom-board` is just a placeholder to load the generic `spidev.c` drivers
  -  NOTE: the CS1 pin / GPIO_62 is *dedicated* to the CS1 pin function and cant be used as GPIO with the current SPI implementation. I think this needs fixing to be able to be used as GPIO and CS1 when using `spi-tools` etc. 
- Fix activity_led name
- Enable CSI/DSI touch controller. The actual focal tech driver still needs to be enabled in the kernel