### PR TITLE
Fix I2C and SPI bus alises

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -32,10 +32,16 @@
 	qcom,msm-id = <0x1f1 0x10000>;
 
 	aliases {
-		serial0 = &uart5;
-		serial1 = &uart7;
-		serial2 = &uart8;
-		serial3 = &uart12;
+		serial0 = &uart5;  // Debug
+		serial1 = &uart7;  // Bluetooth
+		serial2 = &uart8;  // 40 pin: 8,10,11,36
+		serial3 = &uart12; // Syscon
+
+		i2c0 = &i2c0;  // Audio Codec bus @980000
+		i2c1 = &i2c2;  // 40 pin: 3, 5  988000
+		i2c2 = &i2c10; // QWIIC 
+
+		spi0 = &spi14; // 40 pin: 19,21,23,24,26 a98000
 
 		wlan = &wlan;
 		bluetooth = &bluetooth;

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -37,9 +37,9 @@
 		serial2 = &uart8;  // 40 pin: 8,10,11,36
 		serial3 = &uart12; // Syscon
 
-		i2c0 = &i2c0;  // Audio Codec bus @980000
-		i2c1 = &i2c2;  // 40 pin: 3, 5  988000
-		i2c2 = &i2c10; // QWIIC 
+		i2c0 = &i2c0;  // Audio Codec bus
+		i2c1 = &i2c2;  // 40 pin: 3,5
+		i2c2 = &i2c10; // QWIIC
 
 		spi0 = &spi14; // 40 pin: 19,21,23,24,26 a98000
 


### PR DESCRIPTION
Bus numbering matches 20.04 now

```
particle@localhost:~$ ls /dev/spi* -la
crw------- 1 root root 153, 0 Jul 11 18:53 /dev/spidev0.0
crw------- 1 root root 153, 1 Jul 11 18:53 /dev/spidev0.1

particle@localhost:~$ ls /dev/ttyHS* -la
crw-rw---- 1 root dialout 237, 2 Jul 11 18:53 /dev/ttyHS2
crw-rw---- 1 root dialout 237, 3 Jul 11 18:53 /dev/ttyHS3

particle@localhost:~$ ls /dev/i2c* -la
crw-rw---- 1 root i2c 89,  0 Jul 11 18:53 /dev/i2c-0
crw-rw---- 1 root i2c 89,  1 Jul 11 18:53 /dev/i2c-1
crw-rw---- 1 root i2c 89, 13 Jul 11 18:53 /dev/i2c-13
crw-rw---- 1 root i2c 89,  2 Jul 11 18:53 /dev/i2c-2
crw-rw---- 1 root i2c 89,  9 Jul 11 18:53 /dev/i2c-9
```