### PR TITLE
Add waveshare 7" panel support

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtsi
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtsi
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2025 Particle Industries, Inc. All rights reserved.
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+
+&mdss {
+	status = "okay";
+};
+
+&mdss_dsi_phy {
+	vdds-supply = <&vreg_l10c_0p88>;
+	status = "okay";
+};
+
+&mdss_dsi {
+	vdda-supply = <&vreg_l6b_1p2>;
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <1>;
+			mdss_dsi0_out: endpoint {
+				remote-endpoint = <&waveshare_panel_in>;
+			};
+		};
+	};
+
+	waveshare_panel: panel@0 {
+		reg = <0>;
+		compatible = "waveshare,7.0-dsi-touch-a";
+		reset-gpio = <&waveshare_panel_regulator 1 GPIO_ACTIVE_HIGH>;
+		iovcc-gpio = <&waveshare_panel_regulator 4 GPIO_ACTIVE_HIGH>;
+		avdd-gpio = <&waveshare_panel_regulator 0 GPIO_ACTIVE_HIGH>;
+		backlight = <&waveshare_panel_regulator>;
+
+		port {
+			waveshare_panel_in: endpoint {
+				remote-endpoint = <&mdss_dsi0_out>;
+			};
+		};
+	};
+};
+
+&i2c13 {
+	status = "okay";
+    qcom,load-firmware;
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	waveshare_panel_regulator: regulator@45 {
+		compatible = "waveshare,touchscreen-panel-regulator";
+		reg = <0x45>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		enable-gpio = <&waveshare_panel_regulator 2 GPIO_ACTIVE_HIGH>;
+	};
+
+	waveshare_ts: gt911@5d {
+		compatible = "goodix,gt9271";
+		reg = <0x5d>;
+		reset-gpio = <&waveshare_panel_regulator 9 GPIO_ACTIVE_HIGH>;
+	};
+
+};

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtsi
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtsi
@@ -53,6 +53,8 @@
 	status = "okay";
     qcom,load-firmware;
 
+    clock-frequency = <100000>;
+
 	#address-cells = <1>;
 	#size-cells = <0>;
 

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtso
@@ -7,3 +7,7 @@
 /plugin/;
 
 #include "qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtsi"
+
+&waveshare_panel {
+    rotation = <90>;
+};

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtso
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2025 Particle Industries, Inc. All rights reserved.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include "qcm6490-tachyon-vc4-kms-dsi-waveshare-panel-v2.dtsi"

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -1349,7 +1349,7 @@
 // CSI/DSI I2C Bus for touch controller
 &i2c13 {
     status = "okay";
-    clock-frequency = <400000>;
+    clock-frequency = <100000>;
     qcom,load-firmware;
 };
 

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -1349,7 +1349,7 @@
 // CSI/DSI I2C Bus for touch controller
 &i2c13 {
     status = "okay";
-    clock-frequency = <100000>;
+    clock-frequency = <400000>;
     qcom,load-firmware;
 };
 


### PR DESCRIPTION
- DSI i2c bus needs to run at 100khz for maximum compatibility with regulator/touch/backlight devices
- Overlay specifically for `waveshare,7.0-dsi-touch-a` panel. Broader compatibility for different panel sizes needs to be added still