### PR TITLE
Fix usart aliases to be consistent with 20.04

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -33,9 +33,10 @@
 
 	aliases {
 		serial0 = &uart5;  // Debug
-		serial1 = &uart7;  // Bluetooth
-		serial2 = &uart8;  // 40 pin: 8,10,11,36
-		serial3 = &uart12; // Syscon
+		
+		hsuart0 = &uart7;  // Bluetooth
+		hsuart1 = &uart12; // Syscon
+		hsuart2 = &uart8;  // 40 pin: 8,10,11,36
 
 		i2c0 = &i2c0;  // Audio Codec bus
 		i2c1 = &i2c2;  // 40 pin: 3,5


### PR DESCRIPTION
Main reason for this is to make sure syscon usart is `/dev/ttyHS1` on both OS builds