### PR TITLE
Allow DSI overlays to control DSI/CSI switch 

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx519-csi2.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx519-csi2.dtso
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Particle Tachyon camera overlay
+ *
+ * IMX519 on CSI2.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/qcom,camcc-sc7280.h>
+#include <dt-bindings/gpio/gpio.h>
+
+&camcc {
+	status = "okay";
+};
+
+&camss {
+	status = "okay";
+
+	vdda-supply = <&vreg_l5b_0p752>;
+	vdda-phy-supply = <&vreg_l10c_0p88>;
+	vdda-pll-supply = <&vreg_l6b_1p2>;
+
+	/* Provide OPPs for the shared CAMSS power-domain */
+	operating-points-v2 = <&camss_opp_table>;
+
+	camss_opp_table: opp-table {
+		compatible = "operating-points-v2";
+
+		opp-200000000 {
+			opp-hz = /bits/ 64 <200000000>;
+			required-opps = <&rpmhpd_opp_low_svs>;
+		};
+
+		opp-600000000 {
+			opp-hz = /bits/ 64 <600000000>;
+			required-opps = <&rpmhpd_opp_nom>;
+		};
+	};
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <1>;
+			csiphy1_ep: endpoint {
+				clock-lanes = <7>;
+				data-lanes = <0 1>;
+				remote-endpoint = <&imx519_ep>;
+			};
+		};
+	};
+};
+
+&tlmm {
+	// DSI/CSI switch control - set to camera mode
+	dsi_csi_sw_display: dsi-csi-sw-display-state {
+		pins = "gpio68";
+		function = "gpio";
+		drive-strength = <2>;
+		output-high;  // Select display mode (low=display, high=camera)
+		bias-disable;
+	};
+};
+
+&cci0 {
+	status = "okay";
+};
+
+&cci0_i2c1 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	imx519: camera@1a {
+		compatible = "sony,imx519";
+		reg = <0x1a>;
+
+		/* Expose standard V4L2 camera properties for libcamera */
+		orientation = <2>; /* V4L2_FWNODE_ORIENTATION_EXTERNAL */
+		rotation = <0>; /* degrees, 0..359 */
+
+		reset-gpios = <&tlmm 21 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&csi2_mclk_default &csi2_reset_default
+			     &csi2_power_en_default &dsi_csi_sw_display>;
+		pinctrl-1 = <&csi2_mclk_sleep &csi2_reset_sleep
+			     &csi2_power_en_sleep>;
+
+		clocks = <&camcc CAM_CC_MCLK1_CLK>;
+		assigned-clocks = <&camcc CAM_CC_MCLK1_CLK>;
+		assigned-clock-rates = <24000000>;
+
+		VANA-supply = <&cam_vana_2p8>;
+		VDIG-supply = <&cam_vdig_1p05>;
+		VDDL-supply = <&cam_vddl_1p8>;
+
+		status = "okay";
+
+		port {
+			imx519_ep: endpoint {
+				clock-lanes = <7>;
+				link-frequencies = /bits/ 64 <493500000>;
+				data-lanes = <0 1>;
+				remote-endpoint = <&csiphy1_ep>;
+			};
+		};
+	};
+};

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -790,7 +790,7 @@
 &tlmm {
 	pinctrl-names = "default";
 	pinctrl-0 = <&header_40pin_gpio_default>, <&peri_5v_en_default>,
-       <&dsi_csi_sw_en_default>, <&dsi_csi_sw_sel_default>, <&syscon_rgb_reserved_default>,
+       <&dsi_csi_sw_en_default>, <&syscon_rgb_reserved_default>,
 		   <&syscon_bls_invoke_ctrl_default>, <&syscon_reset_ctrl_default>, <&level_shifter_en_default>;
 
 	csi1_mclk_default: csi1-mclk-default-state {
@@ -833,6 +833,52 @@
 
 	csi1_power_en_sleep: csi1-power-en-sleep-state {
 		pins = "gpio107";
+		function = "gpio";
+		drive-strength = <2>;
+		output-low;
+		bias-pull-down;
+	};
+
+	csi2_mclk_default: csi2-mclk-default-state {
+		pins = "gpio65";
+		function = "cam_mclk";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	csi2_mclk_sleep: csi2-mclk-sleep-state {
+		pins = "gpio65";
+		function = "cam_mclk";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+
+	csi2_reset_default: csi2-reset-default-state {
+		pins = "gpio54";
+		function = "gpio";
+		drive-strength = <2>;
+		output-high;
+		bias-disable;
+	};
+
+	csi2_reset_sleep: csi2-reset-sleep-state {
+		pins = "gpio54";
+		function = "gpio";
+		drive-strength = <2>;
+		output-low;
+		bias-pull-down;
+	};
+
+	csi2_power_en_default: csi2-power-en-default-state {
+		pins = "gpio12";
+		function = "gpio";
+		drive-strength = <2>;
+		output-high;
+		bias-disable;
+	};
+
+	csi2_power_en_sleep: csi2-power-en-sleep-state {
+		pins = "gpio12";
 		function = "gpio";
 		drive-strength = <2>;
 		output-low;
@@ -985,14 +1031,6 @@
 
 	dsi_csi_sw_en_default: dsi-csi-sw-en-state {
 		pins = "gpio15";
-		function = "gpio";
-		drive-strength = <2>;
-		output-low;
-		bias-disable;
-	};
-
-	dsi_csi_sw_sel_default: dsi-csi-sw-sel-state {
-		pins = "gpio68";
 		function = "gpio";
 		drive-strength = <2>;
 		output-low;


### PR DESCRIPTION
Remove DSI/CSI switch state from base DTB. Overlays that use DSI/CSI2 connector should configure GPIO68 for their use. This PR fixes the DSI panels by allowing them to claim the GPIO and configure it as needed

Also adding in CSI2 IMX519 camera. 