### PR TITLE
Add DT support for the IMX335 camera

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx335-csi1.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx335-csi1.dtso
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Particle Tachyon camera overlay
+ *
+ * IMX335 on CSI1.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/qcom,camcc-sc7280.h>
+#include <dt-bindings/gpio/gpio.h>
+
+&camcc {
+	status = "okay";
+};
+
+&camss {
+	status = "okay";
+
+	vdda-supply = <&vreg_l5b_0p752>;
+	vdda-phy-supply = <&vreg_l10c_0p88>;
+	vdda-pll-supply = <&vreg_l6b_1p2>;
+
+	/* Provide OPPs for the shared CAMSS power-domain */
+	operating-points-v2 = <&camss_opp_table>;
+
+	camss_opp_table: opp-table {
+		compatible = "operating-points-v2";
+
+		opp-200000000 {
+			opp-hz = /bits/ 64 <200000000>;
+			required-opps = <&rpmhpd_opp_low_svs>;
+		};
+
+		opp-600000000 {
+			opp-hz = /bits/ 64 <600000000>;
+			required-opps = <&rpmhpd_opp_nom>;
+		};
+	};
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@3 {
+			reg = <3>;
+
+			csiphy3_ep: endpoint {
+				clock-lanes = <7>;
+				data-lanes = <0 1 2 3>;
+				remote-endpoint = <&imx335_ep>;
+			};
+		};
+	};
+};
+
+&cci1 {
+	status = "okay";
+};
+
+&cci1_i2c0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	imx335: camera@1a {
+		compatible = "sony,imx335";
+		reg = <0x1a>;
+
+		/* Expose standard V4L2 camera properties for libcamera */
+		orientation = <2>; /* V4L2_FWNODE_ORIENTATION_EXTERNAL */
+		rotation = <0>; /* degrees, 0..359 */
+
+		reset-gpios = <&tlmm 141 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&csi1_mclk_default &csi1_reset_default
+			     &csi1_power_en_default>;
+		pinctrl-1 = <&csi1_mclk_sleep &csi1_reset_sleep
+			     &csi1_power_en_sleep>;
+
+		clocks = <&camcc CAM_CC_MCLK3_CLK>;
+		assigned-clocks = <&camcc CAM_CC_MCLK3_CLK>;
+		assigned-clock-rates = <24000000>;
+
+		avdd-supply = <&cam_vana_2p8>;
+		ovdd-supply = <&cam_vddl_1p8>;
+		dvdd-supply = <&vreg_l6b_1p2>;
+
+		status = "okay";
+
+		port {
+			imx335_ep: endpoint {
+				clock-lanes = <7>;
+				link-frequencies = /bits/ 64 <594000000>;
+				data-lanes = <0 1 2 3>;
+				remote-endpoint = <&csiphy3_ep>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
### Solution
Add DT support for the IMX335 camera on the CSI1.

### Steps to Test
Setup
```c
mount /dev/sda10 /mnt/userdata
mkdir -p /mnt/userdata/boot && cd /mnt/userdata/boot

nano overlays.txt
overlays=qcm6490-tachyon-camera-imx335-csi1.dtbo

adb push ./qcm6490-tachyon-camera-imx335-csi1.dtbo /mnt/userdata/boot
```

Capture image
```c
sudo apt install -y \
  libcamera0.2 \
  libcamera-tools \
  libcamera-ipa \
  libcamera-v4l2
  
cam -c1 -C1 -s role=raw,width=2592,height=1944 -Fframe_2592_1944.dng
```

### References
- IMX335 Camera
