### PR TITLE
Enable SD card functionality

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -1098,6 +1098,43 @@
 			drive-strength = <16>;
 		};
 	};
+
+	sd_cd: sd-cd-state {
+		pins = "gpio91";
+		function = "gpio";
+		bias-pull-up;
+		input-enable;
+	};
+};
+
+&sdc2_clk {
+	drive-strength = <16>;
+	bias-disable;
+};
+
+&sdc2_cmd {
+	drive-strength = <10>;
+	bias-pull-up;
+};
+
+&sdc2_data {
+	drive-strength = <10>;
+	bias-pull-up;
+};
+
+// SD Card controller to work
+&sdhc_2 {
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&sdc2_clk>, <&sdc2_cmd>, <&sdc2_data>, <&sd_cd>;
+	pinctrl-1 = <&sdc2_clk_sleep>, <&sdc2_cmd_sleep>, <&sdc2_data_sleep>, <&sd_cd>;
+	vmmc-supply = <&vreg_l9c_2p96>;
+	vqmmc-supply = <&vreg_l6c_2p96>;
+	cd-gpios = <&tlmm 91 GPIO_ACTIVE_LOW>;
+	bus-width = <4>;
+	no-sdio;
+	no-mmc;
+
+	status = "okay";
 };
 
 // These are required for UFS to work


### PR DESCRIPTION
### Solution
SD card functionality is supported.

### Steps to Test
Setup:
u-boot
```c
make distclean
make qcm6490_tachyon_config
export CROSS_COMPILE=aarch64-linux-gnu-
make -j$(nproc)
```
Ubuntu
```c
// mount sd
sudo mkdir -p /mnt/sdcard
sudo mount /dev/mmcblk1p1 /mnt/sdcard

// write
dd if=/dev/zero of=/mnt/sdcard/testfile bs=1M count=1024 conv=fdatasync
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 23.8497 s, 45.0 MB/s

// read
dd if=/mnt/sdcard/testfile of=/dev/null bs=1M count=1024
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 12.4543 s, 86.2 MB/s

```

SD Card Operating Mode Information
```c
# cat /sys/kernel/debug/mmc1/ios
clock:		202000000 Hz
actual clock:	201999975 Hz
vdd:		23 (3.5 ~ 3.6 V)
bus mode:	2 (push-pull)
chip select:	0 (don't care)
power mode:	2 (on)
bus width:	2 (4 bits)
timing spec:	6 (sd uhs SDR104)
signal voltage:	1 (1.80 V)
driver type:	0 (driver type B)
```

### References
- SD card

