### PR TITLE
dt: update eud node and connect to usb_1

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -239,7 +239,7 @@
 					reg = <0>;
 
 					pmic_glink_hs_in: endpoint {
-						remote-endpoint = <&usb_1_dwc3_hs>;
+						remote-endpoint = <&eud_con>;
 					};
 				};
 
@@ -1348,8 +1348,22 @@
 	};
 };
 
-&usb_1_dwc3_hs {
+&eud {
+	usb-role-switch;
+	qcom,manage-on-role-changes;
+	status = "okay";
+};
+
+&eud_con {
 	remote-endpoint = <&pmic_glink_hs_in>;
+};
+
+&eud_ep {
+	remote-endpoint = <&usb_1_dwc3_hs>;
+};
+
+&usb_1_dwc3_hs {
+	remote-endpoint = <&eud_ep>;
 };
 
 // &usb_1_dwc3_ss {
@@ -1446,7 +1460,8 @@
 
 		port@1 {
 			usb2_role_switch: endpoint {
-				remote-endpoint = <&eud_ep>;
+				// remote-endpoint = <&eud_ep>;
+				// XXX: this is weird now that EUD is connected to usb_1
 			};
 		};
 	};

--- a/dts/upstream/src/arm64/qcom/sc7280.dtsi
+++ b/dts/upstream/src/arm64/qcom/sc7280.dtsi
@@ -5589,11 +5589,13 @@
 		};
 
 		eud: eud@88e0000 {
-			compatible = "qcom,eud";
+			compatible = "qcom,secure-eud";
 			reg = <0 0x88e0000 0 0x2000>,
 			      <0 0x88e2000 0 0x1000>;
 			interrupts-extended = <&pdc 11 IRQ_TYPE_LEVEL_HIGH>;
 
+			phys = <&usb_1_hsphy>;
+			phy-names = "usb2-phy";
 			status = "disabled";
 
 			ports {
@@ -5603,7 +5605,12 @@
 				port@0 {
 					reg = <0>;
 					eud_ep: endpoint {
-						remote-endpoint = <&usb2_role_switch>;
+					};
+				};
+
+				port@1 {
+					reg = <1>;
+					eud_con: endpoint {
 					};
 				};
 			};


### PR DESCRIPTION
Fixes usb_1 device/host usb role switch issues. Required for https://github.com/particle-iot/tachyon-ubuntu-24.04-kernel/pull/23

All PRs required:
https://github.com/particle-iot/tachyon-u-boot/pull/32
https://github.com/particle-iot/tachyon-overlays/pull/12
https://github.com/particle-iot/tachyon-ubuntu-24.04-kernel/pull/23

See https://github.com/particle-iot/tachyon-composer/pull/42 for a prebuilt release.