### PR TITLE
Fix camera regulator voltage

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx219-csi1.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx219-csi1.dtso
@@ -84,8 +84,8 @@
 		assigned-clock-rates = <24000000>;
 
 		VANA-supply = <&cam_vana_2p8>;
-		VDIG-supply = <&cam_vdig_1p05>;
-		VDDL-supply = <&cam_vddl_1p8>;
+		VDIG-supply = <&cam_vdig_1p8>;
+		VDDL-supply = <&cam_vddl_1p2>;
 
 		status = "okay";
 

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx219-csi2.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx219-csi2.dtso
@@ -93,9 +93,9 @@
 		assigned-clocks = <&camcc CAM_CC_MCLK1_CLK>;
 		assigned-clock-rates = <24000000>;
 
-		avdd-supply = <&cam_vana_2p8>;
-		ovdd-supply = <&cam_vddl_1p8>;
-		dvdd-supply = <&vreg_l6b_1p2>;
+		VANA-supply = <&cam_vana_2p8>;
+		VDIG-supply = <&cam_vdig_1p8>;
+		VDDL-supply = <&cam_vddl_1p2>;
 
 		status = "okay";
 

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx335-csi1.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx335-csi1.dtso
@@ -84,8 +84,8 @@
 		assigned-clock-rates = <24000000>;
 
 		avdd-supply = <&cam_vana_2p8>;
-		ovdd-supply = <&cam_vddl_1p8>;
-		dvdd-supply = <&vreg_l6b_1p2>;
+		ovdd-supply = <&cam_vdig_1p8>;
+		dvdd-supply = <&cam_vddl_1p2>;
 
 		status = "okay";
 

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx335-csi2.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx335-csi2.dtso
@@ -94,8 +94,8 @@
 		assigned-clock-rates = <24000000>;
 
 		avdd-supply = <&cam_vana_2p8>;
-		ovdd-supply = <&cam_vddl_1p8>;
-		dvdd-supply = <&vreg_l6b_1p2>;
+		ovdd-supply = <&cam_vdig_1p8>;
+		dvdd-supply = <&cam_vddl_1p2>;
 
 		status = "okay";
 

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx519-csi1.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx519-csi1.dtso
@@ -83,8 +83,8 @@
 		assigned-clock-rates = <24000000>;
 
 		VANA-supply = <&cam_vana_2p8>;
-		VDIG-supply = <&cam_vdig_1p05>;
-		VDDL-supply = <&cam_vddl_1p8>;
+		VDIG-supply = <&cam_vdig_1p8>;
+		VDDL-supply = <&cam_vddl_1p2>;
 
 		status = "okay";
 

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx519-csi2.dtso
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-camera-imx519-csi2.dtso
@@ -94,8 +94,8 @@
 		assigned-clock-rates = <24000000>;
 
 		VANA-supply = <&cam_vana_2p8>;
-		VDIG-supply = <&cam_vdig_1p05>;
-		VDDL-supply = <&cam_vddl_1p8>;
+		VDIG-supply = <&cam_vdig_1p8>;
+		VDDL-supply = <&cam_vddl_1p2>;
 
 		status = "okay";
 

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -54,6 +54,24 @@
 		regulator-boot-on;
 	};
 
+	cam_vdig_1p8: regulator-cam-vdig-1p8 {
+		compatible = "regulator-fixed";
+		regulator-name = "cam_vdig_1p8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	cam_vddl_1p2: regulator-cam-vddl-1p2 {
+		compatible = "regulator-fixed";
+		regulator-name = "cam_vddl_1p2";
+		regulator-min-microvolt = <1200000>;
+		regulator-max-microvolt = <1200000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
 	cam_vddl_1p8: regulator-cam-vddl-1p8 {
 		compatible = "regulator-fixed";
 		regulator-name = "cam_vddl_1p8";

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -45,15 +45,6 @@
 		regulator-boot-on;
 	};
 
-	cam_vdig_1p05: regulator-cam-vdig-1p05 {
-		compatible = "regulator-fixed";
-		regulator-name = "cam_vdig_1p05";
-		regulator-min-microvolt = <1050000>;
-		regulator-max-microvolt = <1050000>;
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
 	cam_vdig_1p8: regulator-cam-vdig-1p8 {
 		compatible = "regulator-fixed";
 		regulator-name = "cam_vdig_1p8";
@@ -68,15 +59,6 @@
 		regulator-name = "cam_vddl_1p2";
 		regulator-min-microvolt = <1200000>;
 		regulator-max-microvolt = <1200000>;
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
-	cam_vddl_1p8: regulator-cam-vddl-1p8 {
-		compatible = "regulator-fixed";
-		regulator-name = "cam_vddl_1p8";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
 		regulator-always-on;
 		regulator-boot-on;
 	};


### PR DESCRIPTION
### Solution
Fix the camera regulator voltage to be compatible with Tachyon RoW and NA boards

### Steps to Test
Setup:
u-boot
```c
make distclean
make qcm6490_tachyon_config
export CROSS_COMPILE=aarch64-linux-gnu-
make -j$(nproc)
```
Ubuntu
```c
mount /dev/sda10 /mnt/userdata
mkdir -p /mnt/userdata/boot && cd /mnt/userdata/boot

nano overlays.txt
overlays=qcm6490-tachyon-camera-imx335-csi1.dtbo qcm6490-tachyon-camera-imx219-csi2.dtbo 


adb push ./qcm6490-tachyon-camera-imx335-csi1.dtbo /mnt/userdata/boot
adb push ./qcm6490-tachyon-camera-imx219-csi2.dtbo /mnt/userdata/boot
```

Capture image:
```c
sudo apt install -y \
  libcamera0.2 \
  libcamera-tools \
  libcamera-ipa \
  libcamera-v4l2

cam -c1 -C1 -s role=raw,width=2592,height=1944 -Fframe1_imx335_2592_1944.dng
cam -c2 -C1 -s role=raw,width=3264,height=2464 -Fframe_3264_2464.dng
```

### References
- IMX219 Camera
- IMX335 Camera
- IMX519 Camera
