### PR TITLE
Enable some QCOM extras (SMC, HDCP etc...)

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon-addons.dtsi
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon-addons.dtsi
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Tachyon-specific addons for TEE/smcinvoke and thermal support
+ * Based on qcm6490-addons.dtsi but adapted for Tachyon memory layout
+ *
+ * Copyright (c) 2025 Particle Industries, Inc. All rights reserved.
+ */
+
+/ {
+	reserved-memory {
+		qseecom_mem: qcom,qseecom {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0x0 0x400000>;
+			size = <0x0 0x1400000>; /* 20M */
+		};
+
+		qseecom_ta_mem: qcom,qseecom-ta {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0x0 0x400000>;
+			size = <0x0 0x1000000>; /* 16M */
+		};
+
+		cdsp_secure_heap: secure-cdsp-region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0x0 0x400000>;
+			size = <0x0 0x2000000>; /* 32M */
+		};
+	};
+
+	firmware {
+		qtee_shmbridge {
+			compatible = "qcom,tee-shared-memory-bridge";
+		};
+
+		qcom_smcinvoke {
+			compatible = "qcom,smcinvoke";
+		};
+	};
+};
+
+/* CPU thermal-idle cooling devices */
+&CPU0 {
+	CPU0_idle: thermal-idle {
+		#cooling-cells = <2>;
+		duration-us = <2000000>;
+		exit-latency-us = <10000>;
+	};
+};
+
+&CPU1 {
+	CPU1_idle: thermal-idle {
+		#cooling-cells = <2>;
+		duration-us = <2000000>;
+		exit-latency-us = <10000>;
+	};
+};
+
+&CPU2 {
+	CPU2_idle: thermal-idle {
+		#cooling-cells = <2>;
+		duration-us = <2000000>;
+		exit-latency-us = <10000>;
+	};
+};
+
+&CPU3 {
+	CPU3_idle: thermal-idle {
+		#cooling-cells = <2>;
+		duration-us = <2000000>;
+		exit-latency-us = <10000>;
+	};
+};
+
+&CPU4 {
+	CPU4_idle: thermal-idle {
+		#cooling-cells = <2>;
+		duration-us = <2000000>;
+		exit-latency-us = <10000>;
+	};
+};
+
+&CPU5 {
+	CPU5_idle: thermal-idle {
+		#cooling-cells = <2>;
+		duration-us = <2000000>;
+		exit-latency-us = <10000>;
+	};
+};
+
+&CPU6 {
+	CPU6_idle: thermal-idle {
+		#cooling-cells = <2>;
+		duration-us = <2000000>;
+		exit-latency-us = <10000>;
+	};
+};
+
+&CPU7 {
+	CPU7_idle: thermal-idle {
+		#cooling-cells = <2>;
+		duration-us = <2000000>;
+		exit-latency-us = <10000>;
+	};
+};

--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -21,6 +21,7 @@
 #include "pm7325.dtsi"
 #include "pm8350c.dtsi"
 #include "pmk8350.dtsi"
+#include "qcm6490-tachyon-addons.dtsi"
 
 /delete-node/ &rmtfs_mem;
 


### PR DESCRIPTION
 Kernel Side enables:
 
  - The qcom_smcinvoke driver is upstream in mainline Linux
  - Device tree needs qcom,smcinvoke and qcom,tee-shared-memory-bridge nodes (done in your qcm6490-tachyon-addons.dtsi)

  Architecture:
  Userspace App → libqcomtee (TEE Client API) → /dev/smcinvoke → Kernel driver → TrustZone
                                                      ↑
                                qtee_supplicant (handles callbacks from TZ)

  What Is Now Working

  1. /dev/smcinvoke - kernel interface (verified working)
  2. Module auto-load via overlay
  3. HDCP firmware present at /usr/lib/firmware/updates/hdcp*.mdt

  What's Needed for Full TEE (noting that SMC is not TEE, but SMC is used by 24.04...)

  To get secure keystore, HDCP, DRM working, you'd need to build:
  1. QCBOR → libqcomtee → minkipc (in that order)
  2. Then run qtee_supplicant daemon
  3. Apps link against libqcomtee to talk to TrustZone