### PR TITLE
codec: enable venus codec, increase vpu firmware size

### DIFF
--- a/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
+++ b/dts/upstream/src/arm64/qcom/qcm6490-tachyon.dts
@@ -308,10 +308,7 @@
 			no-map;
 		};
 
-		video@8ad00000 {
-			reg = <0x00 0x8ad00000 0x00 0x500000>;
-			no-map;
-		};
+		/* Removed - video_mem override below uses this address range */
 
 		removed_region@c0000000 {
 			reg = <0x00 0xc0000000 0x00 0x5100000>;
@@ -337,6 +334,13 @@
 
 &reserved_xbl_uefi_log {
 	reg = <0x00 0x80880000 0x00 0x14000>;
+};
+
+/* Place video_mem at 0x8ad00000 (after cdsp ends) with 7MB.
+ * Gap between cdsp@0x8ad00000 and ipa-fw@0x8b700000 = 10MB available.
+ */
+&video_mem {
+	reg = <0x0 0x8ad00000 0x0 0x700000>;
 };
 
 // Disable WCN6750 wifi, we have a different one, added below
@@ -1489,6 +1493,10 @@
 
 &gpu_zap_shader {
 	firmware-name = "a660_zap.mdt";
+	status = "okay";
+};
+
+&venus {
 	status = "okay";
 };
 


### PR DESCRIPTION
There is support for the VPU hardware in our 6.8 kernel with the `qcom,sc7280-venus` [drivers](https://github.com/particle-iot/tachyon-ubuntu-24.04-kernel/tree/main/drivers/media/platform/qcom/venus). 
These drivers load VPU firmware from `/lib/firmware/qcom/vpu-2.0/venus.mbn`, our filesystem has compressed firmware `venus.mbn.zst` but the driver can decompress and load it successfully. 

There are newer `iris` drivers, but the current implementation in the 6.8 kernel is less functional than the venus drivers.  
Currently the 6.8 venus driver only supports hardware decoding (Decoding crashes the system, likely because of firmware/trustzone incompatibilities). 

You can test with ffmpeg by software encoding a test file, then using the `h264_v4l2m2m` decoder to decode the file:
```
ffmpeg -f lavfi -i testsrc=duration=2:size=640x480:rate=30 \
    -c:v libx264 -pix_fmt yuv420p test.h264 -y && \
    ffmpeg -c:v h264_v4l2m2m -i test.h264 -f null -
```

